### PR TITLE
Replace outdated references to posix.PROT.NONE

### DIFF
--- a/libtest.zig
+++ b/libtest.zig
@@ -19,7 +19,7 @@ export fn t_shuffle(p: [*]u64, n: usize) void {
 }
 
 fn testMapLength(length: usize) !bool {
-    const memory = posix.mmap(null, length, posix.PROT.NONE, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0) catch |err| return switch (err) {
+    const memory = posix.mmap(null, length, .{}, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0) catch |err| return switch (err) {
         error.OutOfMemory => false,
         else => err,
     };
@@ -50,7 +50,7 @@ fn t_vmfill(p: [*][*]align(std.heap.page_size_min) u8, n: [*]usize, len: c_int) 
             }
         }
 
-        const memory = posix.mmap(null, length, posix.PROT.NONE, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0) catch return -1;
+        const memory = posix.mmap(null, length, .{}, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0) catch return -1;
         if (i < len) {
             p[i] = memory.ptr;
             n[i] = memory.len;


### PR DESCRIPTION
This was preventing the test cases from building.

The changes to the posix.PROT interface can be seen here:

https://codeberg.org/ziglang/zig/commit/4d6d2922b814d9f6885cfeec7603e73e9a852417#diff-5288b6cc0f5ceeca2f2a0fa62fef866d2ff21729

The solution is to replace the references to `posix.PROT.NONE` with empty anonymous structs.

Before changes:

```
$ zig build test -Dtarget=aarch64-linux-musl
test
└─ run exe fmodf
   └─ compile exe fmodf Debug aarch64-linux-musl
      └─ compile lib test Debug aarch64-linux-musl 1 errors
libtest.zig:22:55: error: struct 'os.linux.PROT__struct_1328' has no member named 'NONE'
    const memory = posix.mmap(null, length, posix.PROT.NONE, .{ .TYPE = .PRIVATE, .ANONYMOUS = true }, -1, 0) catch |err| return switch (err) {
                                            ~~~~~~~~~~^~~~~
.../zig/zig-aarch64-linux-0.16.0/lib/std/os/linux.zig:3852:20: note: struct declared here
    else => packed struct(u32) {
            ~~~~~~~^~~~~~
referenced by:
    t_vmfill: libtest.zig:38:31
    comptime: libtest.zig:109:18
    4 reference(s) hidden; use '-freference-trace=6' to see all references
error: 1 compilation errors

...

Build Summary: 1/511 steps succeeded (1 failed)
```

After changes:

```
$ zig build test -Dtarget=aarch64-linux-musl

```

Running Zig 0.16.0 on a Lima VM on a Macbook Pro M1.